### PR TITLE
Map blocksLight and map the other Material classes

### DIFF
--- a/mappings/net/minecraft/world/level/material/DecorationMaterial.mapping
+++ b/mappings/net/minecraft/world/level/material/DecorationMaterial.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_541 net/minecraft/world/level/material/DecorationMaterial

--- a/mappings/net/minecraft/world/level/material/GasMaterial.mapping
+++ b/mappings/net/minecraft/world/level/material/GasMaterial.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_263 net/minecraft/world/level/material/GasMaterial

--- a/mappings/net/minecraft/world/level/material/Material.mapping
+++ b/mappings/net/minecraft/world/level/material/Material.mapping
@@ -50,4 +50,5 @@ CLASS net/minecraft/class_15 net/minecraft/world/level/material/Material
 	METHOD method_903 notAlwaysDestroyable ()Lnet/minecraft/class_15;
 	METHOD method_904 flammable ()Lnet/minecraft/class_15;
 	METHOD method_905 isSolid ()Z
+	METHOD method_906 blocksLight ()Z
 	METHOD method_907 blocksMotion ()Z

--- a/mappings/net/minecraft/world/level/material/PortalMaterial.mapping
+++ b/mappings/net/minecraft/world/level/material/PortalMaterial.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_333 net/minecraft/world/level/material/PortalMaterial


### PR DESCRIPTION
This pull request maps GasMaterial, DecorationMaterial, and PortalMaterial.

As well as that, it also maps `blocksLight` in Material.